### PR TITLE
Add lap tracking utilities

### DIFF
--- a/24h_velo.py
+++ b/24h_velo.py
@@ -1,0 +1,46 @@
+import argparse
+from datetime import datetime
+from sauvgarde import load_data, save_data
+
+
+def add_lap(team: str, time_sec: float, filename: str = "data.json"):
+    data = load_data(filename)
+    if team not in data:
+        data[team] = []
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "time_sec": time_sec,
+    }
+    data[team].append(entry)
+    save_data(data, filename)
+
+
+def summary(filename: str = "data.json"):
+    data = load_data(filename)
+    for team, laps in data.items():
+        total = sum(lap["time_sec"] for lap in laps)
+        print(f"{team}: {len(laps)} tours, {total:.2f} s au total")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gestion des temps pour les 24h vélo")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Ajouter un tour")
+    add_parser.add_argument("team", help="Nom de l'equipe")
+    add_parser.add_argument("time", type=float, help="Temps du tour en secondes")
+    add_parser.add_argument("--file", default="data.json", help="Fichier de sauvegarde")
+
+    sum_parser = subparsers.add_parser("summary", help="Afficher le résumé")
+    sum_parser.add_argument("--file", default="data.json", help="Fichier de sauvegarde")
+
+    args = parser.parse_args()
+    if args.command == "add":
+        add_lap(args.team, args.time, args.file)
+    elif args.command == "summary":
+        summary(args.file)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-#24HVELO
+# 24HVELO
 Programme de suivi pour les 24h vélo.
 
 Ce projet vise à créer un programme permettant de suivre et enregistrer les chronos des tours pendant les 24 heures vélo.
 Le système permettra de suivre les performances du Vélo 1, du Vélo 2, ainsi que du peloton en temps réel.
+
+## Utilisation
+
+Deux scripts Python sont fournis :
+
+- `24h_velo.py` : outil en ligne de commande pour enregistrer les tours et afficher un résumé.
+- `sauvgarde.py` : module interne gérant la lecture et l'écriture du fichier de données JSON.
+
+Pour ajouter un tour :
+```bash
+python 24h_velo.py add "Velo 1" 78.5
+```
+
+Pour afficher le résumé :
+```bash
+python 24h_velo.py summary
+```
+

--- a/sauvgarde.py
+++ b/sauvgarde.py
@@ -1,0 +1,16 @@
+import json
+from typing import Any, Dict
+
+
+def load_data(filename: str) -> Dict[str, Any]:
+    try:
+        with open(filename, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def save_data(data: Dict[str, Any], filename: str):
+    with open(filename, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+


### PR DESCRIPTION
## Summary
- add CLI for adding laps and showing summary
- add JSON persistence helpers
- document usage in README

## Testing
- `python -m py_compile 24h_velo.py sauvgarde.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c0969f84832c8828ade925db101c